### PR TITLE
Feature: Adicionar funcionalidade para capturar histórico de tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+env_api-zoho/
 *.py[cod]
 
 .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 boto3
 python-dotenv
 requests==2.32.3
+
+pandas
+s3fs
+fastparquet
+numpy<2

--- a/utils.py
+++ b/utils.py
@@ -127,9 +127,15 @@ def send_data_to_s3(
             )
 
             pathlib.Path(file).unlink()
+    elif path.is_file():  # Adicionando suporte para arquivo único
+        s3_client.upload_file(
+            Filename=str(path),
+            Bucket="501464632998-prod-landing-corporate",
+            Key=f"zohodesk/{domain}/{path.name}"
+        )
+        path.unlink()  # Remove o arquivo local após o envio
     else:
-        # TODO: 
-        pass
+        logging.error(f"Path {path} não é válido.")
     
     return calls.get(domain)
 


### PR DESCRIPTION
### Descrição das alterações

**🆕 Novos métodos em `zohodesk.py`:**
- `get_ticket_history`: Recupera o histórico de um ticket individual.
- `get_ticket_ids_from_parquet`: Extrai os IDs dos tickets de arquivos Parquet para processamento.
- `process_ticket_histories`: Orquestra o processo de busca e armazenamento do histórico de tickets.

**🔧 Melhorias em `utils.py`:**
- Ajustado o método `send_data_to_s3` para tratar tanto diretórios quanto arquivos individuais.
- Melhorias no log para maior visibilidade e manutenção.

---

### Motivação

Essas alterações são necessárias para capturar e armazenar eficientemente o histórico de tickets da API ZohoDesk. Os ajustes também ajudam a minimizar erros relacionados ao limite de requisições da API e melhoram o processo de envio de dados para o AWS S3.

---

### Testes realizados

- Verificado localmente que os métodos interagem corretamente com a API ZohoDesk e o AWS S3.

---

### Próximos passos

- [ ] Revisar e aprovar este PR.
- [ ] Realizar o merge na branch `main`.